### PR TITLE
Add docker compose support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,5 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+results/
+

--- a/Dockerfile.orchestrator
+++ b/Dockerfile.orchestrator
@@ -1,0 +1,8 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt /app/
+RUN pip install --no-cache-dir -r requirements.txt
+
+ENTRYPOINT ["python", "-m", "saheeli.cli"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,30 @@
 # Saheeli
 
 Saheeli orchestrates Docker-based Servo agents to execute complex tasks. This repository contains the host controller and the Servo worker implementation.
+
+## Docker Compose v2
+
+Saheeli can run inside a container using **docker compose v2**. The compose
+configuration mounts the repository and the Docker socket so the orchestrator can
+launch Servo containers on the host.
+
+1. Copy `.env.example` to `.env` and set `OPENAI_API_KEY`.
+2. Build the image:
+
+```bash
+docker compose build
+```
+
+3. Run the CLI:
+
+```bash
+docker compose run --rm saheeli --help
+```
+
+Tasks can then be submitted from within the container:
+
+```bash
+docker compose run --rm saheeli task submit --prompt /app/prompts/validation_task.md
+```
+
+Result artifacts are written to `results/` on the host.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '2.4'
+services:
+  saheeli:
+    build:
+      context: .
+      dockerfile: Dockerfile.orchestrator
+    volumes:
+      - .:/app
+      - ./results:/app/results
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+    command: ["python", "-m", "saheeli.cli"]


### PR DESCRIPTION
## Summary
- provide Dockerfile for orchestrator container
- add docker-compose configuration
- document compose usage in README
- ignore results directory
- switch compose configuration to version 2
- document docker compose build step

## Testing
- `pylint $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684df451495483238f62122db98eea7b