### PR TITLE
Add health checks and tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,6 @@ RUN pip install --no-cache-dir -r /app/requirements.txt
 USER servo
 WORKDIR /workspace
 
+HEALTHCHECK CMD ["python", "-m", "servo.healthcheck"]
+
 ENTRYPOINT ["python", "/app/servo/main.py"]

--- a/Dockerfile.orchestrator
+++ b/Dockerfile.orchestrator
@@ -5,4 +5,6 @@ WORKDIR /app
 COPY requirements.txt /app/
 RUN pip install --no-cache-dir -r requirements.txt
 
+HEALTHCHECK CMD ["python", "-m", "saheeli.healthcheck"]
+
 ENTRYPOINT ["python", "-m", "saheeli.cli"]

--- a/README.md
+++ b/README.md
@@ -28,3 +28,12 @@ docker compose run --rm saheeli task submit --prompt /app/prompts/validation_tas
 ```
 
 Result artifacts are written to `results/` on the host.
+
+Both images expose a simple health check used by Docker:
+
+```bash
+docker compose run --rm saheeli python -m saheeli.healthcheck
+docker compose run --rm servo python -m servo.healthcheck
+```
+
+`docker compose ps` will report the health status for each container.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,4 +10,21 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+    healthcheck:
+      test: ["CMD", "python", "-m", "saheeli.healthcheck"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
     command: ["python", "-m", "saheeli.cli"]
+
+  servo:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ./results:/workspace
+    healthcheck:
+      test: ["CMD", "python", "-m", "servo.healthcheck"]
+      interval: 10s
+      timeout: 5s
+      retries: 3

--- a/saheeli/healthcheck.py
+++ b/saheeli/healthcheck.py
@@ -1,0 +1,24 @@
+import sys
+from .config import load_config
+
+
+def check_config() -> bool:
+    """Return True if configuration loads successfully."""
+    try:
+        load_config()
+        return True
+    except Exception:
+        return False
+
+
+def main() -> int:
+    """Health check entrypoint for the Saheeli container."""
+    if check_config():
+        print("OK")
+        return 0
+    print("Configuration error", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/saheeli/healthcheck.py
+++ b/saheeli/healthcheck.py
@@ -7,7 +7,7 @@ def check_config() -> bool:
     try:
         load_config()
         return True
-    except Exception:
+    except (ConfigError, FileNotFoundError):
         return False
 
 

--- a/servo/healthcheck.py
+++ b/servo/healthcheck.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+import sys
+
+
+def check_workspace(path: Path = Path("/workspace")) -> bool:
+    """Return True if the workspace directory exists."""
+    return path.exists()
+
+
+def main() -> int:
+    """Simple health check entrypoint."""
+    if check_workspace():
+        print("OK")
+        return 0
+    print("Workspace missing", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from servo.healthcheck import check_workspace
+from saheeli.healthcheck import check_config
+
+def test_servo_check_workspace(tmp_path):
+    path = tmp_path / "workspace"
+    path.mkdir()
+    assert check_workspace(path)
+
+def test_saheeli_check_config():
+    assert check_config()

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -1,8 +1,4 @@
-import sys
 from pathlib import Path
-
-sys.path.append(str(Path(__file__).resolve().parents[1]))
-
 from servo.healthcheck import check_workspace
 from saheeli.healthcheck import check_config
 


### PR DESCRIPTION
## Summary
- add healthcheck modules for orchestrator and servo
- integrate healthchecks into Dockerfiles and docker-compose
- document running the healthchecks
- add unit tests for healthcheck modules

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e1c49095483238cb3504ff154190d